### PR TITLE
Update test_install.R - fix zenodo_record files listing

### DIFF
--- a/tests/testthat/test_install.R
+++ b/tests/testthat/test_install.R
@@ -152,7 +152,7 @@ test_that(
       error = function(e) testthat::skip("Zenodo not available")
     )
     if (!exists("zenodo_record")) testthat::skip()
-    zenodo_files <- sapply(zenodo_record[["files"]], function(x) x[["links"]][["download"]])
+    zenodo_files <- sapply(zenodo_record[["files"]], function(x) x[["download"]])
     tarball <- grep("^.*?_(v|)\\d+\\.\\d+\\.\\d+\\.tar\\.gz$", zenodo_files, value = TRUE)
 
     y <- corpus_install(


### PR DESCRIPTION
Relates to https://github.com/eblondel/zen4R/issues/123
It seems zen4R is not invoked anymore in the _cwbtools_ features but it's used in the _test_install.R_ integration test. The `ZenodoRecord` model for listing files had to be slightly adapted to align on the Zenodo API records endpoint.
This PR is made jointly to fix your tests as warned by CRAN team with the attempt to publish zen4R 0.9 
